### PR TITLE
Throw exception on invalid call from UWP main UI thread

### DIFF
--- a/examples/unityplugin/simple_peer_connection.h
+++ b/examples/unityplugin/simple_peer_connection.h
@@ -30,6 +30,7 @@ class SimplePeerConnection : public webrtc::PeerConnectionObserver,
   SimplePeerConnection() {}
   ~SimplePeerConnection() {}
 
+  // On UWP this will throw an exception if called from the main UI thread.
   bool InitializePeerConnection(const char** turn_urls,
                                 const int no_of_urls,
                                 const char* username,


### PR DESCRIPTION
Throw an exception if `SimplePeerConnection::InitializePeerConnection()`
is called on UWP from the main UI thread, to avoid deadlocking later in
`WebRtcFactory::setup()`.

This is a fix for [#143 of webrtc-uwp-sdk](https://github.com/webrtc-uwp/webrtc-uwp-sdk/issues/143)