### PR TITLE
Support 7-microphone array devices

### DIFF
--- a/modules/audio_device/win/audio_device_core_win.cc
+++ b/modules/audio_device/win/audio_device_core_win.cc
@@ -491,6 +491,7 @@ AudioDeviceWindowsCore::AudioDeviceWindowsCore()
   _recChannelsPrioList[0] = 2;  // stereo is prio 1
   _recChannelsPrioList[1] = 1;  // mono is prio 2
   _recChannelsPrioList[2] = 4;  // quad is prio 3
+  _recChannelsPrioList[3] = 7;  // azure kinect have 7
 
   // list of number of channels to use on playout side
   _playChannelsPrioList[0] = 2;  // stereo is prio 1


### PR DESCRIPTION
Plugging in an Azure Kinect device will break peer connection initialization with the following error.

    #
    # Fatal error in: ../../media/engine/webrtcvoiceengine.cc, line 253
    # last system error: 0
    # Check failed: adm()
    #

 [Azure Kinect](https://docs.microsoft.com/en-us/azure/kinect-dk/hardware-specification#microphone-array) doesn't work because it has 7-microphone array and this lib only supports audio capture devices with 4 channels.