### PR TITLE
Fix Lint error in ssl_stream_adapter_unittest.cc

### DIFF
--- a/rtc_base/ssl_stream_adapter_unittest.cc
+++ b/rtc_base/ssl_stream_adapter_unittest.cc
@@ -1334,7 +1334,7 @@ TEST_P(SSLStreamAdapterTestDTLS, TestDTLSExporter) {
 
 // Test not yet valid certificates are not rejected.
 TEST_P(SSLStreamAdapterTestDTLS, TestCertNotYetValid) {
-  long one_day = 60 * 60 * 24;
+  int one_day = 60 * 60 * 24;
   // Make the certificates not valid until one day later.
   ResetIdentitiesWithValidity(one_day, one_day);
   TestHandshake();
@@ -1342,7 +1342,7 @@ TEST_P(SSLStreamAdapterTestDTLS, TestCertNotYetValid) {
 
 // Test expired certificates are not rejected.
 TEST_P(SSLStreamAdapterTestDTLS, TestCertExpired) {
-  long one_day = 60 * 60 * 24;
+  int one_day = 60 * 60 * 24;
   // Make the certificates already expired.
   ResetIdentitiesWithValidity(-one_day, -one_day);
   TestHandshake();


### PR DESCRIPTION
Getting the following error:
Use int16/int64/etc, rather than the C type long [runtime/int] [4]